### PR TITLE
Add system-files plugs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -55,6 +55,30 @@ parts:
     organize:
       ovn-exporter-wrapper: bin/ovn-exporter.wrapper
       hooks/configure: meta/hooks/configure
+plugs:
+  etc-openvswitch:
+    interface: system-files
+    read:
+    - /etc/openvswitch
+  # For Unix sockets read-write permissions are needed even though the
+  # requests over those sockets will be read-only (in order to write a
+  # request we need write permissions).
+  var-run-openvswitch:
+    interface: system-files
+    write:
+    - /var/run/openvswitch
+  run-openvswitch:
+    interface: system-files
+    write:
+    - /run/openvswitch
+  var-run-ovn:
+    interface: system-files
+    write:
+    - /var/run/ovn
+  run-ovn:
+    interface: system-files
+    write:
+    - /run/ovn
 apps:
   ovn-exporter:
     command: 'bin/ovn-exporter.wrapper'
@@ -66,6 +90,11 @@ apps:
       - network-observe
       - netlink-audit
       - kernel-module-observe
+      - etc-openvswitch
+      - var-run-openvswitch
+      - run-openvswitch
+      - var-run-ovn
+      - run-ovn
     daemon: simple
 hooks:
   configure:


### PR DESCRIPTION
In order to allow this snap to run in a strictly-confined mode
additional paths need to be allowed for access by the snap.

Signed-off-by: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>