### PR TITLE
Update to upstream version 1.0.7

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: prometheus-ovn-exporter
-version: 1.0.6
+version: 1.0.7
 base: core20
 grade: stable
 summary: Prometheus OVN Exporter
@@ -18,9 +18,9 @@ architectures:
 parts:
   ovn-exporter:
     plugin: go
-    go-channel: 1.19/stable
+    go-channel: 1.20/stable
     source: https://github.com/greenpau/ovn_exporter.git
-    source-tag: v1.0.6
+    source-tag: v1.0.7
     build-packages:
       - gcc
       - golang-go


### PR DESCRIPTION
Update to the latest upstream version
- Bump the upstream version from 1.0.6 to 1.0.7
- Bump the golang channel from 1.19 to 1.20

There are no specific changes or bugfixes in this release, however it
bumps to newer versions of golang and a number of dependencies.

Having those updated is prudent from a security point of view and the
current snap build is also quite old.

Signed-off-by: Trent Lloyd <trent.lloyd@canonical.com>
